### PR TITLE
Implement workaround to mimic predis 1 during cache clear on symfony/cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [5.3.1] - 2023-02-04
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* Fixed incompatibility between predis 2 and symfony/cache making it impossible to clear cache
+
+
 ## [5.3.0] - 2023-01-28
 ### Added
 * *Nothing*

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,6 +17,7 @@
         </include>
         <exclude>
             <file>./src/Entity/AbstractEntity.php</file>
+            <file>./src/Cache/ShlinkPredisClient.php</file>
         </exclude>
     </coverage>
 </phpunit>

--- a/src/Cache/RedisFactory.php
+++ b/src/Cache/RedisFactory.php
@@ -27,7 +27,7 @@ class RedisFactory
         $servers = $this->resolveServers($redisConfig);
         $options = $this->resolveOptions($redisConfig, $servers);
 
-        return new PredisClient($servers, $options);
+        return new ShlinkPredisClient($servers, $options);
     }
 
     private function resolveServers(array $redisConfig): array

--- a/src/Cache/ShlinkPredisClient.php
+++ b/src/Cache/ShlinkPredisClient.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Common\Cache;
+
+use Predis\Client;
+use Predis\ClientInterface;
+use Predis\Connection\Replication\ReplicationInterface;
+
+use function class_alias;
+
+// FIXME This file is a fix for https://github.com/shlinkio/shlink/issues/1684 for until symfony/cache supports predis 2
+// phpcs:disable
+class_alias(ReplicationInterface::class, 'Predis\Connection\Aggregate\ReplicationInterface');
+
+class ShlinkPredisClient extends Client
+{
+    public function getClientFor(string $name): ClientInterface
+    {
+        return parent::getClientBy('role', $name);
+    }
+}


### PR DESCRIPTION
Refs https://github.com/shlinkio/shlink/issues/1684