### PR TITLE
urldecode username and password from Redis connection uri

### DIFF
--- a/src/Cache/RedisFactory.php
+++ b/src/Cache/RedisFactory.php
@@ -16,6 +16,7 @@ use function is_string;
 use function parse_url;
 use function sprintf;
 use function trim;
+use function urldecode;
 
 class RedisFactory
 {
@@ -54,10 +55,10 @@ class RedisFactory
         }
 
         if (isset($parsedServer['user']) && ! isset($parsedServer['pass'])) {
-            $parsedServer['password'] = $parsedServer['user'];
+            $parsedServer['password'] = urldecode($parsedServer['user']);
         } elseif (isset($parsedServer['user'], $parsedServer['pass'])) {
-            $parsedServer['username'] = $parsedServer['user'];
-            $parsedServer['password'] = $parsedServer['pass'];
+            $parsedServer['username'] = urldecode($parsedServer['user']);
+            $parsedServer['password'] = urldecode($parsedServer['pass']);
         }
 
         unset($parsedServer['user'], $parsedServer['pass']);


### PR DESCRIPTION
Passwords containing special characters are not accepted in current releases. If url-encoded, the Redis server will be complaining about incorrect username-password pair. If not url-encoded, the RedisFactory class will be complaining about incorrect uri format.

In my opinion, username and password from Redis connection uri should be url-decoded. However, this change might affect users with plain text passwords like "%23".
