### PR TITLE
Allow current request ID to be set and read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* Allow current request ID to be set and read in `RequestIdMiddleware`.
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* *Nothing*
+
+### Removed
+* *Nothing*
+
+### Fixed
+* *Nothing*
+
+
 ## [6.0.0] - 2024-03-03
 ### Added
 * Add new `RequestIdMiddleware`.

--- a/src/Middleware/RequestIdMiddleware.php
+++ b/src/Middleware/RequestIdMiddleware.php
@@ -39,4 +39,19 @@ class RequestIdMiddleware implements MiddlewareInterface, ProcessorInterface
         $record->extra[self::ATTRIBUTE] = $this->currentRequestId;
         return $record;
     }
+
+    // The getter and setter defined here are used to forward a request ID generated at the beginning of a request, to
+    // every job scheduled during that request,
+    //  * With the getter we read the value and pass it serialized with the rest of the job's payload.
+    //  * With the setter we set it at the beginning of the job, into that job's RequestIdMiddleware instance.
+
+    public function setCurrentRequestId(string $requestId): void
+    {
+        $this->currentRequestId = $requestId;
+    }
+
+    public function currentRequestId(): string
+    {
+        return $this->currentRequestId;
+    }
 }

--- a/test/Middleware/RequestIdMiddlewareTest.php
+++ b/test/Middleware/RequestIdMiddlewareTest.php
@@ -51,6 +51,23 @@ class RequestIdMiddlewareTest extends TestCase
     }
 
     #[Test]
+    public function currentRequestIdCanBeRead(): void
+    {
+        self::assertEquals('-', $this->middleware->currentRequestId());
+        $request = ServerRequestFactory::fromGlobals();
+        $this->middleware->process($request, $this->handler);
+        self::assertNotEquals('-', $this->middleware->currentRequestId());
+    }
+
+    #[Test]
+    public function currentRequestIdCanBeSet(): void
+    {
+        self::assertEquals('-', $this->middleware->currentRequestId());
+        $this->middleware->setCurrentRequestId('foobar');
+        self::assertEquals('foobar', $this->middleware->currentRequestId());
+    }
+
+    #[Test]
     public function defaultRequestIdIsSetForLogs(): void
     {
         $result = ($this->middleware)($this->defaultLogRecord());


### PR DESCRIPTION
Part of https://github.com/shlinkio/shlink/issues/2049

The `RequestIdMiddleware` only allowed the request ID to be set via request headers. This PR adds also a setter, so that it can be set in non-request contexts, like during RoadRunner tasks/jobs.