### PR TITLE
Enable missing generics checks with phpstan

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,4 +4,3 @@ includes:
 parameters:
 	ignoreErrors:
 		- identifier: missingType.iterableValue
-		- identifier: missingType.generics

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -21,6 +21,7 @@
         <exclude>
             <file>./src/Entity/AbstractEntity.php</file>
             <file>./src/Cache/ShlinkPredisClient.php</file>
+            <file>./src/Paginator/Util/PagerfantaUtilsTrait.php</file>
         </exclude>
     </source>
 </phpunit>

--- a/src/Paginator/Paginator.php
+++ b/src/Paginator/Paginator.php
@@ -8,6 +8,10 @@ use Pagerfanta\Pagerfanta;
 
 use function max;
 
+/**
+ * @template T
+ * @extends Pagerfanta<T>
+ */
 class Paginator extends Pagerfanta
 {
     public const ALL_ITEMS = -1;

--- a/src/Paginator/Util/PagerfantaUtils.php
+++ b/src/Paginator/Util/PagerfantaUtils.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Shlinkio\Shlink\Common\Paginator\Util;
+
+use Laminas\Stdlib\ArrayUtils;
+use Pagerfanta\Pagerfanta;
+use Shlinkio\Shlink\Common\Rest\DataTransformerInterface;
+
+use function array_map;
+use function count;
+use function sprintf;
+
+/**
+ * @template T
+ */
+final class PagerfantaUtils
+{
+    /**
+     * @param Pagerfanta<T> $paginator
+     */
+    public static function serializePaginator(
+        Pagerfanta $paginator,
+        ?DataTransformerInterface $transformer = null,
+        string $dataProp = 'data',
+    ): array {
+        $currentPageItems = ArrayUtils::iteratorToArray($paginator->getCurrentPageResults());
+
+        return [
+            $dataProp => self::serializeItems($currentPageItems, $transformer),
+            'pagination' => [
+                'currentPage' => $paginator->getCurrentPage(),
+                'pagesCount' => $paginator->getNbPages(),
+                'itemsPerPage' => $paginator->getMaxPerPage(),
+                'itemsInCurrentPage' => count($currentPageItems),
+                'totalItems' => $paginator->getNbResults(),
+            ],
+        ];
+    }
+
+    private static function serializeItems(array $items, ?DataTransformerInterface $transformer = null): array
+    {
+        return $transformer === null ? $items : array_map([$transformer, 'transform'], $items);
+    }
+
+    /**
+     * @param Pagerfanta<T> $paginator
+     */
+    public static function formatCurrentPageMessage(Pagerfanta $paginator, string $pattern): string
+    {
+        return sprintf($pattern, $paginator->getCurrentPage(), $paginator->getNbPages());
+    }
+}

--- a/src/Paginator/Util/PagerfantaUtils.php
+++ b/src/Paginator/Util/PagerfantaUtils.php
@@ -6,7 +6,6 @@ namespace Shlinkio\Shlink\Common\Paginator\Util;
 
 use Laminas\Stdlib\ArrayUtils;
 use Pagerfanta\Pagerfanta;
-use Shlinkio\Shlink\Common\Rest\DataTransformerInterface;
 
 use function array_map;
 use function count;
@@ -19,16 +18,17 @@ final class PagerfantaUtils
 {
     /**
      * @param Pagerfanta<T> $paginator
+     * @param null|callable(T): mixed $serializer
      */
     public static function serializePaginator(
         Pagerfanta $paginator,
-        ?DataTransformerInterface $transformer = null,
+        ?callable $serializer = null,
         string $dataProp = 'data',
     ): array {
         $currentPageItems = ArrayUtils::iteratorToArray($paginator->getCurrentPageResults());
 
         return [
-            $dataProp => self::serializeItems($currentPageItems, $transformer),
+            $dataProp => self::serializeItems($currentPageItems, $serializer),
             'pagination' => [
                 'currentPage' => $paginator->getCurrentPage(),
                 'pagesCount' => $paginator->getNbPages(),
@@ -39,9 +39,13 @@ final class PagerfantaUtils
         ];
     }
 
-    private static function serializeItems(array $items, ?DataTransformerInterface $transformer = null): array
+    /**
+     * @param T[] $items
+     * @param null|callable(T): array $serializer
+     */
+    private static function serializeItems(array $items, ?callable $serializer = null): array
     {
-        return $transformer === null ? $items : array_map([$transformer, 'transform'], $items);
+        return $serializer === null ? $items : array_map($serializer, $items);
     }
 
     /**

--- a/src/Paginator/Util/PagerfantaUtilsTrait.php
+++ b/src/Paginator/Util/PagerfantaUtilsTrait.php
@@ -21,7 +21,8 @@ trait PagerfantaUtilsTrait
         ?DataTransformerInterface $transformer = null,
         string $dataProp = 'data',
     ): array {
-        return PagerfantaUtils::serializePaginator($paginator, $transformer, $dataProp);
+        $serializer = $transformer !== null ? fn ($value) => $transformer->transform($value) : null;
+        return PagerfantaUtils::serializePaginator($paginator, $serializer, $dataProp);
     }
 
     /**

--- a/src/Paginator/Util/PagerfantaUtilsTrait.php
+++ b/src/Paginator/Util/PagerfantaUtilsTrait.php
@@ -4,42 +4,32 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\Common\Paginator\Util;
 
-use Laminas\Stdlib\ArrayUtils;
 use Pagerfanta\Pagerfanta;
 use Shlinkio\Shlink\Common\Rest\DataTransformerInterface;
 
-use function array_map;
-use function count;
-use function sprintf;
-
+/**
+ * @deprecated Use PagerfantaUtils instead
+ */
 trait PagerfantaUtilsTrait
 {
+    /**
+     * @template T
+     * @param Pagerfanta<T> $paginator
+     */
     private function serializePaginator(
         Pagerfanta $paginator,
         ?DataTransformerInterface $transformer = null,
         string $dataProp = 'data',
     ): array {
-        $currentPageItems = ArrayUtils::iteratorToArray($paginator->getCurrentPageResults());
-
-        return [
-            $dataProp => $this->serializeItems($currentPageItems, $transformer),
-            'pagination' => [
-                'currentPage' => $paginator->getCurrentPage(),
-                'pagesCount' => $paginator->getNbPages(),
-                'itemsPerPage' => $paginator->getMaxPerPage(),
-                'itemsInCurrentPage' => count($currentPageItems),
-                'totalItems' => $paginator->getNbResults(),
-            ],
-        ];
+        return PagerfantaUtils::serializePaginator($paginator, $transformer, $dataProp);
     }
 
-    private function serializeItems(array $items, ?DataTransformerInterface $transformer = null): array
-    {
-        return $transformer === null ? $items : array_map([$transformer, 'transform'], $items);
-    }
-
+    /**
+     * @template T
+     * @param Pagerfanta<T> $paginator
+     */
     private function formatCurrentPageMessage(Pagerfanta $paginator, string $pattern): string
     {
-        return sprintf($pattern, $paginator->getCurrentPage(), $paginator->getNbPages());
+        return PagerfantaUtils::formatCurrentPageMessage($paginator, $pattern);
     }
 }

--- a/src/Rest/DataTransformerInterface.php
+++ b/src/Rest/DataTransformerInterface.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Shlinkio\Shlink\Common\Rest;
 
+/** @deprecated */
 interface DataTransformerInterface
 {
     /**

--- a/src/Validation/OrderByFilter.php
+++ b/src/Validation/OrderByFilter.php
@@ -9,6 +9,9 @@ use Laminas\Filter\AbstractFilter;
 use function is_string;
 use function Shlinkio\Shlink\Common\parseOrderBy;
 
+/**
+ * @extends AbstractFilter<array{}>
+ */
 class OrderByFilter extends AbstractFilter
 {
     /**

--- a/test/Doctrine/Mapping/EnhancedPHPDriverTest.php
+++ b/test/Doctrine/Mapping/EnhancedPHPDriverTest.php
@@ -17,6 +17,7 @@ use stdClass;
 class EnhancedPHPDriverTest extends TestCase
 {
     private MockObject & FileLocator $loader;
+    /** @var MockObject & ClassMetadata<stdClass> */
     private MockObject & ClassMetadata $meta;
 
     public function setUp(): void

--- a/test/Mock/MockRepository.php
+++ b/test/Mock/MockRepository.php
@@ -6,6 +6,9 @@ namespace ShlinkioTest\Shlink\Common\Mock;
 
 use Doctrine\ORM\EntityRepository;
 
+/**
+ * @extends EntityRepository<object>
+ */
 class MockRepository extends EntityRepository
 {
 }

--- a/test/Paginator/PaginatorTest.php
+++ b/test/Paginator/PaginatorTest.php
@@ -11,9 +11,14 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Shlinkio\Shlink\Common\Paginator\Paginator;
 
+/**
+ * @template T
+ */
 class PaginatorTest extends TestCase
 {
+    /** @var Paginator<T> */
     private Paginator $paginator;
+    /** @var MockObject & AdapterInterface<T> */
     private MockObject & AdapterInterface $adapter;
 
     protected function setUp(): void

--- a/test/Paginator/Util/PagerfantaUtilsTest.php
+++ b/test/Paginator/Util/PagerfantaUtilsTest.php
@@ -90,7 +90,7 @@ class PagerfantaUtilsTest extends TestCase
     #[Test, DataProvider('provideDataProps')]
     public function paginatorIsSerializedWithExpectedDataProp(string $prop): void
     {
-        $result = PagerfantaUtils::serializePaginator(new Pagerfanta(new ArrayAdapter([])), null, $prop);
+        $result = PagerfantaUtils::serializePaginator(new Pagerfanta(new ArrayAdapter([])), dataProp: $prop);
 
         self::assertArrayNotHasKey('data', $result);
         self::assertArrayHasKey($prop, $result);
@@ -101,6 +101,17 @@ class PagerfantaUtilsTest extends TestCase
         yield 'foo' => ['foo'];
         yield 'bar' => ['bar'];
         yield 'something' => ['something'];
+    }
+
+    #[Test]
+    public function paginatorIsSerializedWithProvidedCallback(): void
+    {
+        ['data' => $data] = PagerfantaUtils::serializePaginator(
+            new Pagerfanta(new ArrayAdapter(range(1, 10))),
+            static fn (int $value) => $value * 2,
+        );
+
+        self::assertEquals([2, 4, 6, 8, 10, 12, 14, 16, 18, 20], $data);
     }
 
     /**

--- a/test/Paginator/Util/PagerfantaUtilsTest.php
+++ b/test/Paginator/Util/PagerfantaUtilsTest.php
@@ -9,18 +9,22 @@ use Pagerfanta\Pagerfanta;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
-use Shlinkio\Shlink\Common\Paginator\Util\PagerfantaUtilsTrait;
+use Shlinkio\Shlink\Common\Paginator\Util\PagerfantaUtils;
 
 use function range;
 
-class PagerfantaUtilsTraitTest extends TestCase
+/**
+ * @template T
+ */
+class PagerfantaUtilsTest extends TestCase
 {
-    use PagerfantaUtilsTrait;
-
+    /**
+     * @param Pagerfanta<T> $paginator
+     */
     #[Test, DataProvider('providePaginatorAdapters')]
     public function paginatorIsSerializedAsExpected(array $expectedSerialization, Pagerfanta $paginator): void
     {
-        $result = $this->serializePaginator($paginator);
+        $result = PagerfantaUtils::serializePaginator($paginator);
         self::assertEquals($expectedSerialization, $result);
     }
 
@@ -86,7 +90,7 @@ class PagerfantaUtilsTraitTest extends TestCase
     #[Test, DataProvider('provideDataProps')]
     public function paginatorIsSerializedWithExpectedDataProp(string $prop): void
     {
-        $result = $this->serializePaginator(new Pagerfanta(new ArrayAdapter([])), null, $prop);
+        $result = PagerfantaUtils::serializePaginator(new Pagerfanta(new ArrayAdapter([])), null, $prop);
 
         self::assertArrayNotHasKey('data', $result);
         self::assertArrayHasKey($prop, $result);
@@ -99,13 +103,16 @@ class PagerfantaUtilsTraitTest extends TestCase
         yield 'something' => ['something'];
     }
 
+    /**
+     * @param Pagerfanta<T> $paginator
+     */
     #[Test, DataProvider('providePaginatorsToFormat')]
     public function pageMessageIsProperlyFormatted(
         string $expectedMessage,
         string $pattern,
         Pagerfanta $paginator,
     ): void {
-        self::assertEquals($expectedMessage, $this->formatCurrentPageMessage($paginator, $pattern));
+        self::assertEquals($expectedMessage, PagerfantaUtils::formatCurrentPageMessage($paginator, $pattern));
     }
 
     public static function providePaginatorsToFormat(): iterable

--- a/test/Repository/CustomRepository.php
+++ b/test/Repository/CustomRepository.php
@@ -6,6 +6,9 @@ namespace ShlinkioTest\Shlink\Common\Repository;
 
 use Doctrine\ORM\EntityRepository;
 
+/**
+ * @extends EntityRepository<object>
+ */
 class CustomRepository extends EntityRepository
 {
 }


### PR DESCRIPTION
Up until now, generics checks were disabled in PHPStan. This PR enables the check, and fixes reported errors.

Additionally, this PR deprecates `PagerfantaUtilsTrait` and `DataTransformerInterface`, and provides an alternative static `PagerfantaUtils` class which does not reference `DataTransformerInterface`.