### PR TITLE
Add redis database support

### DIFF
--- a/src/Cache/RedisFactory.php
+++ b/src/Cache/RedisFactory.php
@@ -50,8 +50,9 @@ class RedisFactory
         $parsedServer = parse_url(trim($server));
         if (! is_array($parsedServer)) {
             throw new InvalidArgumentException(sprintf(
-                'Provided server "%s" is not a valid URL with format schema://[[username]:password@]host:port',
+                'Provided server "%s" is not a valid URL with format %s',
                 $server,
+                'schema://[[username]:password@]host:port[/database]',
             ));
         }
 
@@ -71,6 +72,14 @@ class RedisFactory
         }
         if ($pass !== null) {
             $parsedServer['password'] = urldecode($pass);
+        }
+
+        $database = $parsedServer['path'] ?? null;
+        unset($parsedServer['path']);
+
+        if ($database !== null) {
+            // TODO For the next major version, validate this is an integer and throw an exception otherwise
+            $parsedServer['database'] = (int) trim($database, '/');
         }
 
         return $parsedServer;


### PR DESCRIPTION
A redis connection string can have a database number after the port, separated by a slash.

Currently if you try and this in the redis server strings it is not passed in to the client so you can only use database 0.

This gets the path and removes the `/` and casts it to an int as all redis dbs are integers. If the path is not a valid numeric it will set it to 0 which is the current behaviour.