### PR TITLE
Deprecate classes using laminas-inputfilter packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com), and this project adheres to [Semantic Versioning](https://semver.org).
 
+## [Unreleased]
+### Added
+* *Nothing*
+
+### Changed
+* *Nothing*
+
+### Deprecated
+* Deprecate all classes that use `laminas/laminas-inputfilter`, `laminas/laminas-filter` and `laminas/laminas-validtor` packages.
+  The dependency on `laminas/laminas-inputfilter` is now only suggested.
+
+### Removed
+* Drop support for predis 2
+
+### Fixed
+* *Nothing*
+
+
 ## [8.1.0] - 2026-03-08
 ### Added
 * Add support for predis 3

--- a/composer.json
+++ b/composer.json
@@ -14,21 +14,20 @@
     "require": {
         "php": "^8.4",
         "ext-fileinfo": "*",
-        "cakephp/chronos": "^3.2",
-        "doctrine/orm": "^3.5",
+        "cakephp/chronos": "^3.4",
+        "doctrine/orm": "^3.6",
         "fig/http-message-util": "^1.1",
-        "guzzlehttp/guzzle": "^7.9",
-        "laminas/laminas-diactoros": "^3.6",
-        "laminas/laminas-inputfilter": "^2.33",
-        "laminas/laminas-servicemanager": "^3.23",
+        "guzzlehttp/guzzle": "^7.10",
+        "laminas/laminas-diactoros": "^3.8",
+        "laminas/laminas-servicemanager": "^3.24",
         "lcobucci/jwt": "^5.6",
-        "monolog/monolog": "^3.9",
+        "monolog/monolog": "^3.10",
         "php-amqplib/php-amqplib": "^3.7",
-        "predis/predis": "^3.4 || ^2.4",
+        "predis/predis": "^3.4",
         "psr/http-server-middleware": "^1.0",
         "ramsey/uuid": "^4.9",
-        "shlinkio/shlink-config": "^4.0",
-        "shlinkio/shlink-json": "^1.2",
+        "shlinkio/shlink-config": "^4.1",
+        "shlinkio/shlink-json": "^1.3",
         "symfony/cache": "^8.0",
         "symfony/lock": "^8.0",
         "symfony/mercure": "^0.7",
@@ -38,8 +37,9 @@
     "require-dev": {
         "akrabat/ip-address-middleware": "^2.6",
         "devster/ubench": "^2.1",
+        "laminas/laminas-inputfilter": "^2.35",
         "laminas/laminas-stratigility": "^4.3",
-        "mezzio/mezzio-problem-details": "^1.18",
+        "mezzio/mezzio-problem-details": "^1.19",
         "pagerfanta/core": "^3.8",
         "phpstan/phpstan": "^2.1",
         "phpstan/phpstan-phpunit": "^2.0",
@@ -52,7 +52,8 @@
     "suggest": {
         "mezzio/mezzio-problem-details": "To log ProblemDetailsMiddleware errors using the ErrorLogger",
         "laminas/laminas-stratigility": "To log ErrorHandler errors using the ErrorLogger",
-        "pagerfanta/core": "To use the PagerfantaUtilsTrait"
+        "pagerfanta/core": "To use the PagerfantaUtils",
+        "laminas/laminas-inputfilter": "To use laminas filters and validation"
     },
     "autoload": {
         "psr-4": {

--- a/src/Validation/ExcludingValidatorChain.php
+++ b/src/Validation/ExcludingValidatorChain.php
@@ -10,6 +10,7 @@ use function array_replace_recursive;
 
 /**
  * A validator chain which is considered valid as soon as one of its validators is valid
+ * @deprecated
  */
 class ExcludingValidatorChain implements Validator\ValidatorInterface
 {

--- a/src/Validation/HostAndPortValidator.php
+++ b/src/Validation/HostAndPortValidator.php
@@ -20,6 +20,7 @@ use function is_object;
 use function is_string;
 use function sprintf;
 
+/** @deprecated */
 class HostAndPortValidator extends AbstractValidator
 {
     private const INVALID_AMOUNT_OF_PARTS = 'INVALID_AMOUNT_OF_PARTS';

--- a/src/Validation/InputFactory.php
+++ b/src/Validation/InputFactory.php
@@ -13,6 +13,7 @@ use Laminas\Validator;
 use function array_map;
 use function is_numeric;
 
+/** @deprecated */
 final class InputFactory
 {
     public static function basic(string $name, bool $required = false): Input

--- a/src/Validation/OrderByFilter.php
+++ b/src/Validation/OrderByFilter.php
@@ -11,6 +11,7 @@ use function Shlinkio\Shlink\Common\parseOrderBy;
 
 /**
  * @extends AbstractFilter<array{}>
+ * @deprecated
  */
 class OrderByFilter extends AbstractFilter
 {

--- a/src/Validation/OrderByValidator.php
+++ b/src/Validation/OrderByValidator.php
@@ -10,6 +10,7 @@ use function count;
 use function in_array;
 use function is_array;
 
+/** @deprecated */
 class OrderByValidator extends AbstractValidator
 {
     public const VALID_ORDER_DIRS = ['ASC', 'DESC'];

--- a/src/Validation/SluggerFilter.php
+++ b/src/Validation/SluggerFilter.php
@@ -10,6 +10,7 @@ use Symfony\Component\String\Slugger;
 
 use function is_string;
 
+/** @deprecated */
 class SluggerFilter implements FilterInterface
 {
     private Slugger\SluggerInterface $slugger;


### PR DESCRIPTION
In preparation to migrate to use valinor for filtering, validation and mapping, this PR deprecates all classes that use `laminas/laminas-inputfilter`, `laminas/laminas-validator` or `laminas/laminas-filter`, and make the dependency on `laminas/laminas-inputfilter` optional (suggested).